### PR TITLE
add nested object support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ A client should also provide support for these types:
 ``` js
 var other = {
   error        : {type: 'error', message: 'not-supported'},
-  createStream : {type: 'duplex'}
+  createStream : {type: 'duplex'},
+  nested       : {type: 'object', methods: {get: {type: 'async'}}}
 }
 ```
 `error` is used when a method has been disabled.

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var methods = {
 }
 
 //valid types:
-//readable, writable, duplex, sync, async, error
+//readable, writable, duplex, sync, async, error, object
 
 //error means that this method is disabled in the client
 //the client should throw

--- a/test/index.js
+++ b/test/index.js
@@ -125,3 +125,32 @@ test('sets methods', function (t) {
   t.end()
 
 })
+
+test('nested objects', function (t) {
+
+  var error = {type: 'error', message: 'read-only'}
+  var nested = {type: 'object', methods: {get: error}}
+
+  var readOnly = {
+        put              : error,
+        del              : error,
+        batch            : error,
+        writeStream      : error,
+        createWriteStream: error,
+        nested           : nested
+      }
+
+  var db = {
+    methods: readOnly,
+    sublevels: {foo: {methods: readOnly}}
+  }
+
+  var m = manifest(db)
+
+  t.deepEqual(m.methods.nested, nested)
+  t.deepEqual(m.sublevels.foo.methods.nested, nested)
+
+  console.log(inspect(m, false, 10))
+
+  t.end()
+})


### PR DESCRIPTION
This adds nested object support, as in https://github.com/dominictarr/level-manifest/issues/1

For a db with:

``` js
typeof db.nested == 'object'
typeof db.nested.get == 'function'
db.methods == {
  nested: {type: 'object', methods: {get: 'async'}}
}
```

the manifest is:

``` js
manifest(db, true) == {
  nested: {type: 'object', methods: {get: 'async'}}
}
```

I'll be working on a patch for multilevel to support this too.
