### PR TITLE
Add db.options to manifest

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,10 @@ var methods = {
 
 module.exports = function manifest (db, terse) {
   var man = {}
+
+  if(db.options)
+    man.options = db.options
+
   if(db.methods || !terse) man.methods = {}
   if(!terse) {
     deepExtend(deepExtend(man.methods, methods), db.methods)

--- a/test/index.js
+++ b/test/index.js
@@ -69,6 +69,11 @@ test('terse: blank defaults', function (t) {
 
   var error = {type: 'error', message: 'read-only'}
 
+  var options = {
+        keyEncoding      : 'utf8',
+        valueEncoding    : 'utf8'
+      }
+
   var readOnly = {
         put              : error,
         del              : error,
@@ -78,10 +83,12 @@ test('terse: blank defaults', function (t) {
       }
 
   var db = {
+    options: options,
     methods: readOnly,
     sublevels: {
       foo: {},
-      bar: {methods: readOnly}
+      bar: {methods: readOnly},
+      baz: {options: options}
     }
   }
 
@@ -97,6 +104,11 @@ test('blank defaults', function (t) {
 
   var error = {type: 'error', message: 'read-only'}
 
+  var options = {
+        keyEncoding      : 'utf8',
+        valueEncoding    : 'utf8'
+      }
+
   var readOnly = {
         put              : error,
         del              : error,
@@ -106,10 +118,12 @@ test('blank defaults', function (t) {
       }
 
   var db = {
+    options: options,
     methods: readOnly,
     sublevels: {
       foo: {},
-      bar: {methods: readOnly}
+      bar: {methods: readOnly},
+      baz: {options: options}
     }
   }
 


### PR DESCRIPTION
This adds the db options object to the manifest if it exists.

I was looking for a way to access these in my multilevel client and came across this ticket. https://github.com/juliangruber/multilevel/issues/17
